### PR TITLE
correct chained method alias

### DIFF
--- a/lib/alias_application_helper_patch.rb
+++ b/lib/alias_application_helper_patch.rb
@@ -9,7 +9,7 @@ module AliasApplicationHelperPatch
             unloadable
 
             alias_method :parse_redmine_links_without_project_alias, :parse_redmine_links
-            alias_method :parse_redmine_links, :parse_redmine_links_without_project_alias
+            alias_method :parse_redmine_links, :parse_redmine_links_with_project_alias
         end
     end
 


### PR DESCRIPTION
The way it was, you changed the base class `parse_redmine_links` method to `parse_redmine_links_without_project_alias`, then just changed it back.  What you meant to do is replace the base method so it calls `parse_redmine_links_with_project_alias`, which is defined right below, and which calls the original (now renamed) method if needed..

I know.. it took me a while to wrap my head around that too.  :)